### PR TITLE
Add dataset creation workflow for JUMP data:

### DIFF
--- a/src/microsplit_reproducibility/workflows/__init__.py
+++ b/src/microsplit_reproducibility/workflows/__init__.py
@@ -1,0 +1,23 @@
+from .dataset_creation import (
+    JUMPDatasetBuilder,
+    Channel,
+    create_pilot_dataset,
+    create_orf_dataset,
+    create_crispr_dataset,
+    create_compound_dataset,
+    visualize_single_image,
+    visualize_dataset_sample,
+    verify_dataset_structure,
+)
+
+__all__ = [
+    "JUMPDatasetBuilder",
+    "Channel",
+    "create_pilot_dataset",
+    "create_orf_dataset",
+    "create_crispr_dataset",
+    "create_compound_dataset",
+    "visualize_single_image",
+    "visualize_dataset_sample",
+    "verify_dataset_structure",
+]

--- a/src/microsplit_reproducibility/workflows/dataset_creation/__init__.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/__init__.py
@@ -1,0 +1,79 @@
+from .jump_dataset_creation import (
+    Channel,
+    JUMPDataset,
+    DatasetConfig,
+    ImageMetadata,
+    validate_channels,
+    validate_weights,
+    create_directory_structure,
+    normalize_image,
+    combine_channels,
+    save_images,
+    save_metadata,
+    print_dataset_summary
+)
+
+from .jump_image_fetch import (
+    fetch_jump_image,
+    fetch_all_channels
+)
+
+from .jump_metadata import (
+    load_pilot_metadata,
+    load_orf_profiles,
+    load_compound_profiles,
+    load_crispr_profiles,
+    get_location_info,
+    filter_by_batch,
+    get_plates_in_batch,
+    get_wells_in_plate,
+    sample_locations_from_plate,
+    extract_location_from_row
+)
+
+from .jump_perturbation_selection import (
+    get_orf_gene_mapping,
+    select_orfs_by_gene,
+    select_random_orfs,
+    select_crispr_by_gene,
+    select_random_crispr,
+    select_compounds_by_id,
+    select_random_compounds,
+    get_perturbation_type
+)
+
+from .jump_pilot_dataset import create_pilot_dataset
+from .jump_orf_dataset import create_orf_dataset
+from .jump_crispr_dataset import create_crispr_dataset
+from .jump_compound_dataset import create_compound_dataset
+
+from .jump_dataset_visualization import (
+    visualize_single_image,
+    visualize_dataset_sample,
+    verify_dataset_structure,
+    create_5channel_composite,
+    normalize_for_display
+)
+
+from .jump_dataset_workflow import (
+    JUMPDatasetBuilder,
+    list_available_batches,
+    get_batch_info
+)
+
+__all__ = [
+    "Channel",
+    "JUMPDataset",
+    "DatasetConfig",
+    "ImageMetadata",
+    "JUMPDatasetBuilder",
+    "create_pilot_dataset",
+    "create_orf_dataset",
+    "create_crispr_dataset",
+    "create_compound_dataset",
+    "visualize_single_image",
+    "visualize_dataset_sample",
+    "verify_dataset_structure",
+    "list_available_batches",
+    "get_batch_info",
+]

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_compound_dataset.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_compound_dataset.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from typing import List, Optional
+import numpy as np
+from .jump_dataset_creation import (
+    ImageMetadata,
+    Channel,
+    validate_channels,
+    validate_weights,
+    create_directory_structure,
+    combine_channels,
+    save_images,
+    save_metadata,
+    print_dataset_summary
+)
+from .jump_metadata import (
+    get_location_info,
+    extract_location_from_row
+)
+from .jump_image_fetch import fetch_all_channels
+
+
+def create_compound_dataset(
+    compound_ids: List[str],
+    channels: List[Channel],
+    output_dir: Path,
+    images_per_compound: int = 5,
+    normalize: bool = False,
+    weights: Optional[List[float]] = None,
+    seed: int = 42,
+    source: str = "source_4"
+) -> List[ImageMetadata]:
+    
+    validate_channels(channels)
+    channel_names = [ch.value for ch in channels]
+    weights = validate_weights(weights, len(channels))
+    
+    create_directory_structure(output_dir, channels)
+    
+    metadata_list = []
+    image_counter = 0
+    
+    total_target = len(compound_ids) * images_per_compound
+    print(f"Creating compound dataset: {len(compound_ids)} compounds × {images_per_compound} images = {total_target} total images")
+    print(f"Output directory: {output_dir}")
+    
+    np.random.seed(seed)
+    
+    for compound_idx, compound_id in enumerate(compound_ids, 1):
+        print(f"\nProcessing compound {compound_idx}/{len(compound_ids)}: {compound_id}")
+        
+        try:
+            location_info = get_location_info(compound_id)
+        except RuntimeError as e:
+            print(f"Skipping {compound_id}: {e}")
+            continue
+        
+        if len(location_info) == 0:
+            print(f"No images found for {compound_id}")
+            continue
+        
+        available_images = len(location_info)
+        num_to_sample = min(images_per_compound, available_images)
+        
+        if num_to_sample < images_per_compound:
+            print(f"Warning: Only {available_images} images available, sampling {num_to_sample}")
+        
+        sampled_indices = np.random.choice(
+            available_images,
+            size=num_to_sample,
+            replace=False
+        )
+        
+        images_processed = 0
+        
+        for sample_idx in sampled_indices:
+            row = location_info.row(int(sample_idx), named=True)
+            source_str, batch, plate, well, site = extract_location_from_row(row)
+            
+            print(f"Processing image {images_processed + 1}/{num_to_sample}: {source_str}/{batch}/{plate}/{well}/site_{site}")
+            
+            try:
+                channel_images = fetch_all_channels(
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                
+                combined_image, stats = combine_channels(
+                    channel_images,
+                    channel_names,
+                    weights,
+                    normalize
+                )
+                
+                save_images(
+                    combined_image,
+                    channel_images,
+                    image_counter,
+                    output_dir,
+                    channel_names
+                )
+                
+                metadata = ImageMetadata(
+                    image_id=image_counter,
+                    perturbation_id=compound_id,
+                    perturbation_type="compound",
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                metadata_list.append(metadata)
+                
+                image_counter += 1
+                images_processed += 1
+                
+            except RuntimeError as e:
+                print(f"Failed to process image: {e}")
+                continue
+        
+        print(f"Successfully processed {images_processed}/{num_to_sample} images for {compound_id}")
+    
+    save_metadata(metadata_list, output_dir)
+    print_dataset_summary(metadata_list, output_dir, channel_names)
+    
+    return metadata_list

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_crispr_dataset.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_crispr_dataset.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from typing import List, Optional, Dict
+import numpy as np
+from .jump_dataset_creation import (
+    ImageMetadata,
+    Channel,
+    validate_channels,
+    validate_weights,
+    create_directory_structure,
+    combine_channels,
+    save_images,
+    save_metadata,
+    print_dataset_summary
+)
+from .jump_metadata import (
+    load_crispr_profiles,
+    get_location_info,
+    extract_location_from_row
+)
+from .jump_image_fetch import fetch_all_channels
+
+
+def create_crispr_dataset(
+    crispr_ids: List[str],
+    channels: List[Channel],
+    output_dir: Path,
+    images_per_perturbation: int = 5,
+    normalize: bool = False,
+    weights: Optional[List[float]] = None,
+    seed: int = 42,
+    source: str = "source_4",
+    gene_mapping: Optional[Dict[str, str]] = None
+) -> List[ImageMetadata]:
+    
+    validate_channels(channels)
+    channel_names = [ch.value for ch in channels]
+    weights = validate_weights(weights, len(channels))
+    
+    create_directory_structure(output_dir, channels)
+    
+    metadata_list = []
+    image_counter = 0
+    
+    total_target = len(crispr_ids) * images_per_perturbation
+    print(f"Creating CRISPR dataset: {len(crispr_ids)} perturbations × {images_per_perturbation} images = {total_target} total images")
+    print(f"Output directory: {output_dir}")
+    
+    np.random.seed(seed)
+    
+    for crispr_idx, crispr_id in enumerate(crispr_ids, 1):
+        gene_symbol = gene_mapping.get(crispr_id, "Unknown") if gene_mapping else None
+        print(f"\nProcessing CRISPR {crispr_idx}/{len(crispr_ids)}: {crispr_id}")
+        
+        if gene_symbol:
+            print(f"Gene symbol: {gene_symbol}")
+        
+        try:
+            location_info = get_location_info(crispr_id)
+        except RuntimeError as e:
+            print(f"Skipping {crispr_id}: {e}")
+            continue
+        
+        if len(location_info) == 0:
+            print(f"No images found for {crispr_id}")
+            continue
+        
+        available_images = len(location_info)
+        num_to_sample = min(images_per_perturbation, available_images)
+        
+        if num_to_sample < images_per_perturbation:
+            print(f"Warning: Only {available_images} images available, sampling {num_to_sample}")
+        
+        sampled_indices = np.random.choice(
+            available_images,
+            size=num_to_sample,
+            replace=False
+        )
+        
+        images_processed = 0
+        
+        for sample_idx in sampled_indices:
+            row = location_info.row(int(sample_idx), named=True)
+            source_str, batch, plate, well, site = extract_location_from_row(row)
+            
+            print(f"Processing image {images_processed + 1}/{num_to_sample}: {source_str}/{batch}/{plate}/{well}/site_{site}")
+            
+            try:
+                channel_images = fetch_all_channels(
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                
+                combined_image, stats = combine_channels(
+                    channel_images,
+                    channel_names,
+                    weights,
+                    normalize
+                )
+                
+                save_images(
+                    combined_image,
+                    channel_images,
+                    image_counter,
+                    output_dir,
+                    channel_names
+                )
+                
+                metadata = ImageMetadata(
+                    image_id=image_counter,
+                    perturbation_id=crispr_id,
+                    perturbation_type="crispr",
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names,
+                    gene_symbol=gene_symbol
+                )
+                metadata_list.append(metadata)
+                
+                image_counter += 1
+                images_processed += 1
+                
+            except RuntimeError as e:
+                print(f"Failed to process image: {e}")
+                continue
+        
+        print(f"Successfully processed {images_processed}/{num_to_sample} images for {crispr_id}")
+    
+    save_metadata(metadata_list, output_dir)
+    print_dataset_summary(metadata_list, output_dir, channel_names)
+    
+    return metadata_list

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_creation.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_creation.py
@@ -1,0 +1,185 @@
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+import numpy as np
+import pandas as pd
+import tifffile
+from dataclasses import dataclass
+from enum import Enum
+
+
+class JUMPDataset(Enum):
+    PILOT = "cpg0000-jump-pilot"
+    ORF = "cpg0016-jump"
+    CRISPR = "cpg0016-jump"
+    COMPOUND = "cpg0016-jump"
+
+
+class Channel(Enum):
+    DNA = "DNA"
+    RNA = "RNA"
+    ER = "ER"
+    AGP = "AGP"
+    MITO = "Mito"
+
+
+@dataclass
+class DatasetConfig:
+    dataset_type: JUMPDataset
+    channels: List[Channel]
+    output_dir: Path
+    num_images: int
+    images_per_perturbation: int
+    seed: int = 42
+    normalize: bool = False
+    weights: Optional[List[float]] = None
+    source: str = "source_4"
+
+
+@dataclass
+class ImageMetadata:
+    image_id: int
+    perturbation_id: str
+    perturbation_type: str
+    source: str
+    batch: str
+    plate: str
+    well: str
+    site: int
+    channels: List[str]
+    gene_symbol: Optional[str] = None
+
+
+def validate_channels(channels: List[Channel]) -> None:
+    if len(channels) < 2:
+        raise ValueError("At least 2 channels required for MicroSplit")
+    
+    if len(channels) != len(set(channels)):
+        raise ValueError("Duplicate channels specified")
+
+
+def validate_weights(weights: Optional[List[float]], num_channels: int) -> List[float]:
+    if weights is None:
+        return [1.0 / num_channels] * num_channels
+    
+    if len(weights) != num_channels:
+        raise ValueError(f"Number of weights ({len(weights)}) must match number of channels ({num_channels})")
+    
+    if not np.isclose(sum(weights), 1.0):
+        raise ValueError(f"Weights must sum to 1.0, got {sum(weights)}")
+    
+    return weights
+
+
+def create_directory_structure(output_dir: Path, channels: List[Channel]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "combined").mkdir(exist_ok=True)
+    
+    for channel in channels:
+        (output_dir / channel.value).mkdir(exist_ok=True)
+
+
+def normalize_image(image: np.ndarray) -> np.ndarray:
+    image_float = image.astype(np.float32)
+    min_val = image_float.min()
+    max_val = image_float.max()
+    
+    if max_val > min_val:
+        return (image_float - min_val) / (max_val - min_val)
+    return image_float
+
+
+def combine_channels(
+    channel_images: Dict[str, np.ndarray],
+    channels: List[str],
+    weights: List[float],
+    normalize: bool = False
+) -> Tuple[np.ndarray, Dict[str, float]]:
+    
+    if normalize:
+        normalized_images = {
+            ch: normalize_image(img) for ch, img in channel_images.items()
+        }
+    else:
+        normalized_images = channel_images
+    
+    combined = np.zeros_like(list(normalized_images.values())[0], dtype=np.float32)
+    
+    for channel, weight in zip(channels, weights):
+        combined += weight * normalized_images[channel]
+    
+    stats = {
+        "mean": float(combined.mean()),
+        "std": float(combined.std()),
+        "min": float(combined.min()),
+        "max": float(combined.max())
+    }
+    
+    return combined, stats
+
+
+def save_images(
+    combined_image: np.ndarray,
+    channel_images: Dict[str, np.ndarray],
+    image_id: int,
+    output_dir: Path,
+    channels: List[str]
+) -> Dict[str, Path]:
+    
+    paths = {}
+    
+    combined_filename = f"img_{image_id:05d}_combined.tif"
+    combined_path = output_dir / "combined" / combined_filename
+    tifffile.imwrite(combined_path, combined_image)
+    paths["combined"] = combined_path
+    
+    for channel in channels:
+        channel_filename = f"img_{image_id:05d}_{channel}.tif"
+        channel_path = output_dir / channel / channel_filename
+        tifffile.imwrite(channel_path, channel_images[channel])
+        paths[channel] = channel_path
+    
+    return paths
+
+
+def save_metadata(metadata_list: List[ImageMetadata], output_dir: Path) -> Path:
+    records = []
+    for metadata in metadata_list:
+        record = {
+            "image_id": metadata.image_id,
+            "perturbation_id": metadata.perturbation_id,
+            "perturbation_type": metadata.perturbation_type,
+            "source": metadata.source,
+            "batch": metadata.batch,
+            "plate": metadata.plate,
+            "well": metadata.well,
+            "site": metadata.site,
+            "combined_channels": "_".join(metadata.channels),
+        }
+        
+        if metadata.gene_symbol:
+            record["gene_symbol"] = metadata.gene_symbol
+        
+        records.append(record)
+    
+    df = pd.DataFrame(records)
+    metadata_path = output_dir / "metadata.csv"
+    df.to_csv(metadata_path, index=False)
+    
+    return metadata_path
+
+
+def print_dataset_summary(
+    metadata_list: List[ImageMetadata],
+    output_dir: Path,
+    channels: List[str]
+) -> None:
+    
+    print(f"\nDataset created with {len(metadata_list)} images")
+    print(f"- Combined images saved to: {output_dir / 'combined'}")
+    
+    for channel in channels:
+        channel_count = sum(1 for _ in (output_dir / channel).glob("*.tif"))
+        print(f"- {channel} channel: {channel_count} images saved to: {output_dir / channel}")
+    
+    print(f"- Metadata saved to: {output_dir / 'metadata.csv'}")
+    print("\nDataset creation complete!")

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_visualization.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_visualization.py
@@ -1,0 +1,228 @@
+from pathlib import Path
+from typing import List, Optional
+import numpy as np
+import matplotlib.pyplot as plt
+import tifffile
+import pandas as pd
+from matplotlib.colors import LinearSegmentedColormap
+
+
+CHANNEL_COLORS = {
+    "DNA": "blue",
+    "RNA": "yellow",
+    "ER": "green",
+    "AGP": "orange",
+    "Mito": "red"
+}
+
+
+def create_channel_colormap(channel_name: str) -> LinearSegmentedColormap:
+    
+    color = CHANNEL_COLORS.get(channel_name, "gray")
+    
+    if color == "yellow":
+        colors = ["black", "yellow"]
+    elif color == "blue":
+        colors = ["black", "blue"]
+    elif color == "green":
+        colors = ["black", "green"]
+    elif color == "orange":
+        colors = ["black", "orange"]
+    elif color == "red":
+        colors = ["black", "red"]
+    else:
+        colors = ["black", "white"]
+    
+    return LinearSegmentedColormap.from_list(f"{channel_name}_cmap", colors)
+
+
+def normalize_for_display(image: np.ndarray, percentile: float = 99.5) -> np.ndarray:
+    
+    vmin = np.percentile(image, 100 - percentile)
+    vmax = np.percentile(image, percentile)
+    
+    normalized = (image - vmin) / (vmax - vmin)
+    return np.clip(normalized, 0, 1)
+
+
+def visualize_single_image(
+    dataset_dir: Path,
+    image_id: int,
+    channels: List[str],
+    figsize: tuple = (15, 5)
+) -> plt.Figure:
+    
+    num_channels = len(channels)
+    fig, axes = plt.subplots(1, num_channels + 2, figsize=figsize)
+    
+    combined_path = dataset_dir / "combined" / f"img_{image_id:05d}_combined.tif"
+    combined = tifffile.imread(combined_path)
+    combined_norm = normalize_for_display(combined)
+    
+    axes[0].imshow(combined_norm, cmap="gray")
+    axes[0].set_title("Combined")
+    axes[0].axis("off")
+    
+    for idx, channel in enumerate(channels, 1):
+        channel_path = dataset_dir / channel / f"img_{image_id:05d}_{channel}.tif"
+        channel_img = tifffile.imread(channel_path)
+        channel_norm = normalize_for_display(channel_img)
+        
+        cmap = create_channel_colormap(channel)
+        axes[idx].imshow(channel_norm, cmap=cmap)
+        axes[idx].set_title(channel)
+        axes[idx].axis("off")
+    
+    if len(channels) == 5:
+        composite = create_5channel_composite(dataset_dir, image_id, channels)
+        axes[-1].imshow(composite)
+        axes[-1].set_title("5-Channel Composite")
+        axes[-1].axis("off")
+    
+    plt.tight_layout()
+    return fig
+
+
+def create_5channel_composite(
+    dataset_dir: Path,
+    image_id: int,
+    channels: List[str]
+) -> np.ndarray:
+    
+    if len(channels) != 5:
+        raise ValueError("Composite requires exactly 5 channels")
+    
+    channel_order = ["DNA", "Mito", "ER", "RNA", "AGP"]
+    images = []
+    
+    for channel in channel_order:
+        if channel not in channels:
+            raise ValueError(f"Missing channel: {channel}")
+        
+        channel_path = dataset_dir / channel / f"img_{image_id:05d}_{channel}.tif"
+        img = tifffile.imread(channel_path)
+        images.append(normalize_for_display(img))
+    
+    composite = np.zeros((*images[0].shape, 3))
+    
+    composite[..., 2] = images[0]
+    composite[..., 1] = 0.7 * images[2] + 0.3 * images[3]
+    composite[..., 0] = 0.7 * images[1] + 0.3 * images[4]
+    
+    return np.clip(composite, 0, 1)
+
+
+def visualize_dataset_sample(
+    dataset_dir: Path,
+    channels: List[str],
+    num_samples: int = 4,
+    seed: int = 42,
+    figsize: tuple = (20, 5)
+) -> plt.Figure:
+    
+    combined_dir = dataset_dir / "combined"
+    all_images = sorted(combined_dir.glob("img_*.tif"))
+    
+    if len(all_images) == 0:
+        raise ValueError(f"No images found in {combined_dir}")
+    
+    num_samples = min(num_samples, len(all_images))
+    
+    np.random.seed(seed)
+    sampled_indices = np.random.choice(len(all_images), size=num_samples, replace=False)
+    
+    num_channels = len(channels)
+    fig, axes = plt.subplots(num_samples, num_channels + 1, figsize=figsize)
+    
+    if num_samples == 1:
+        axes = axes.reshape(1, -1)
+    
+    for row_idx, img_idx in enumerate(sampled_indices):
+        image_id = int(all_images[img_idx].stem.split('_')[1])
+        
+        combined_path = all_images[img_idx]
+        combined = tifffile.imread(combined_path)
+        combined_norm = normalize_for_display(combined)
+        
+        axes[row_idx, 0].imshow(combined_norm, cmap="gray")
+        axes[row_idx, 0].set_title(f"Combined (ID: {image_id})")
+        axes[row_idx, 0].axis("off")
+        
+        for col_idx, channel in enumerate(channels, 1):
+            channel_path = dataset_dir / channel / f"img_{image_id:05d}_{channel}.tif"
+            channel_img = tifffile.imread(channel_path)
+            channel_norm = normalize_for_display(channel_img)
+            
+            cmap = create_channel_colormap(channel)
+            axes[row_idx, col_idx].imshow(channel_norm, cmap=cmap)
+            axes[row_idx, col_idx].set_title(channel)
+            axes[row_idx, col_idx].axis("off")
+    
+    plt.tight_layout()
+    return fig
+
+
+def verify_dataset_structure(
+    dataset_dir: Path,
+    channels: List[str]
+) -> dict:
+    
+    results = {
+        "valid": True,
+        "issues": [],
+        "statistics": {}
+    }
+    
+    if not dataset_dir.exists():
+        results["valid"] = False
+        results["issues"].append(f"Dataset directory does not exist: {dataset_dir}")
+        return results
+    
+    combined_dir = dataset_dir / "combined"
+    if not combined_dir.exists():
+        results["valid"] = False
+        results["issues"].append("Combined directory missing")
+        return results
+    
+    combined_images = list(combined_dir.glob("img_*.tif"))
+    num_combined = len(combined_images)
+    results["statistics"]["combined_images"] = num_combined
+    
+    if num_combined == 0:
+        results["valid"] = False
+        results["issues"].append("No combined images found")
+        return results
+    
+    for channel in channels:
+        channel_dir = dataset_dir / channel
+        
+        if not channel_dir.exists():
+            results["valid"] = False
+            results["issues"].append(f"Channel directory missing: {channel}")
+            continue
+        
+        channel_images = list(channel_dir.glob(f"img_*_{channel}.tif"))
+        num_channel = len(channel_images)
+        results["statistics"][f"{channel}_images"] = num_channel
+        
+        if num_channel != num_combined:
+            results["valid"] = False
+            results["issues"].append(
+                f"Channel {channel} has {num_channel} images, expected {num_combined}"
+            )
+    
+    metadata_path = dataset_dir / "metadata.csv"
+    if not metadata_path.exists():
+        results["valid"] = False
+        results["issues"].append("Metadata file missing")
+    else:
+        metadata = pd.read_csv(metadata_path)
+        results["statistics"]["metadata_rows"] = len(metadata)
+        
+        if len(metadata) != num_combined:
+            results["valid"] = False
+            results["issues"].append(
+                f"Metadata has {len(metadata)} rows, expected {num_combined}"
+            )
+    
+    return results

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_workflow.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_dataset_workflow.py
@@ -1,0 +1,278 @@
+from pathlib import Path
+from typing import List, Optional, Dict
+from .jump_dataset_creation import Channel, JUMPDataset, ImageMetadata
+from .jump_pilot_dataset import create_pilot_dataset
+from .jump_orf_dataset import create_orf_dataset
+from .jump_crispr_dataset import create_crispr_dataset
+from .jump_compound_dataset import create_compound_dataset
+from .jump_perturbation_selection import (
+    select_random_orfs,
+    select_orfs_by_gene,
+    select_random_crispr,
+    select_crispr_by_gene,
+    select_random_compounds,
+    select_compounds_by_id,
+    get_orf_gene_mapping
+)
+from .jump_metadata import (
+    load_pilot_metadata,
+    load_orf_profiles,
+    load_crispr_profiles,
+    load_compound_profiles,
+    get_plates_in_batch
+)
+from .jump_dataset_visualization import (
+    visualize_single_image,
+    visualize_dataset_sample,
+    verify_dataset_structure
+)
+
+
+class JUMPDatasetBuilder:
+    
+    def __init__(
+        self,
+        dataset_type: str,
+        channels: List[str],
+        output_dir: str,
+        seed: int = 42,
+        source: str = "source_4"
+    ):
+        self.dataset_type = dataset_type.lower()
+        self.channels = [Channel[ch.upper()] for ch in channels]
+        self.output_dir = Path(output_dir)
+        self.seed = seed
+        self.source = source
+        self.metadata_list: Optional[List[ImageMetadata]] = None
+        
+        self._validate_dataset_type()
+    
+    def _validate_dataset_type(self) -> None:
+        valid_types = ["pilot", "orf", "crispr", "compound"]
+        if self.dataset_type not in valid_types:
+            raise ValueError(
+                f"Invalid dataset_type: {self.dataset_type}. "
+                f"Must be one of {valid_types}"
+            )
+    
+    def create_pilot_dataset(
+        self,
+        batch: str,
+        samples_per_plate: int = 5,
+        plates: Optional[List[str]] = None,
+        normalize: bool = False,
+        weights: Optional[List[float]] = None
+    ) -> List[ImageMetadata]:
+        
+        if self.dataset_type != "pilot":
+            raise ValueError("Dataset type must be 'pilot'")
+        
+        self.metadata_list = create_pilot_dataset(
+            batch=batch,
+            channels=self.channels,
+            output_dir=self.output_dir,
+            samples_per_plate=samples_per_plate,
+            plates=plates,
+            normalize=normalize,
+            weights=weights,
+            seed=self.seed,
+            source=self.source
+        )
+        
+        return self.metadata_list
+    
+    def create_orf_dataset_random(
+        self,
+        num_orfs: int,
+        images_per_orf: int = 5,
+        normalize: bool = False,
+        weights: Optional[List[float]] = None
+    ) -> List[ImageMetadata]:
+        
+        if self.dataset_type != "orf":
+            raise ValueError("Dataset type must be 'orf'")
+        
+        profiles = load_orf_profiles(self.source)
+        orf_ids = select_random_orfs(profiles, num_orfs, seed=self.seed)
+        gene_mapping = get_orf_gene_mapping(profiles)
+        
+        self.metadata_list = create_orf_dataset(
+            orf_ids=orf_ids,
+            channels=self.channels,
+            output_dir=self.output_dir,
+            images_per_orf=images_per_orf,
+            normalize=normalize,
+            weights=weights,
+            seed=self.seed,
+            source=self.source,
+            gene_mapping=gene_mapping
+        )
+        
+        return self.metadata_list
+    
+    def create_orf_dataset_by_genes(
+        self,
+        gene_symbols: List[str],
+        images_per_orf: int = 5,
+        normalize: bool = False,
+        weights: Optional[List[float]] = None
+    ) -> List[ImageMetadata]:
+        
+        if self.dataset_type != "orf":
+            raise ValueError("Dataset type must be 'orf'")
+        
+        profiles = load_orf_profiles(self.source)
+        orf_ids = select_orfs_by_gene(profiles, gene_symbols)
+        gene_mapping = get_orf_gene_mapping(profiles)
+        
+        print(f"Found {len(orf_ids)} ORFs for genes: {', '.join(gene_symbols)}")
+        
+        self.metadata_list = create_orf_dataset(
+            orf_ids=orf_ids,
+            channels=self.channels,
+            output_dir=self.output_dir,
+            images_per_orf=images_per_orf,
+            normalize=normalize,
+            weights=weights,
+            seed=self.seed,
+            source=self.source,
+            gene_mapping=gene_mapping
+        )
+        
+        return self.metadata_list
+    
+    def create_crispr_dataset_random(
+        self,
+        num_perturbations: int,
+        images_per_perturbation: int = 5,
+        normalize: bool = False,
+        weights: Optional[List[float]] = None
+    ) -> List[ImageMetadata]:
+        
+        if self.dataset_type != "crispr":
+            raise ValueError("Dataset type must be 'crispr'")
+        
+        profiles = load_crispr_profiles(self.source)
+        crispr_ids = select_random_crispr(profiles, num_perturbations, seed=self.seed)
+        
+        self.metadata_list = create_crispr_dataset(
+            crispr_ids=crispr_ids,
+            channels=self.channels,
+            output_dir=self.output_dir,
+            images_per_perturbation=images_per_perturbation,
+            normalize=normalize,
+            weights=weights,
+            seed=self.seed,
+            source=self.source
+        )
+        
+        return self.metadata_list
+    
+    def create_compound_dataset_random(
+        self,
+        num_compounds: int,
+        images_per_compound: int = 5,
+        normalize: bool = False,
+        weights: Optional[List[float]] = None
+    ) -> List[ImageMetadata]:
+        
+        if self.dataset_type != "compound":
+            raise ValueError("Dataset type must be 'compound'")
+        
+        profiles = load_compound_profiles(self.source)
+        compound_ids = select_random_compounds(profiles, num_compounds, seed=self.seed)
+        
+        self.metadata_list = create_compound_dataset(
+            compound_ids=compound_ids,
+            channels=self.channels,
+            output_dir=self.output_dir,
+            images_per_compound=images_per_compound,
+            normalize=normalize,
+            weights=weights,
+            seed=self.seed,
+            source=self.source
+        )
+        
+        return self.metadata_list
+    
+    def visualize_sample(
+        self,
+        num_samples: int = 4,
+        figsize: tuple = (20, 5)
+    ):
+        
+        if not self.output_dir.exists():
+            raise ValueError(f"Dataset directory does not exist: {self.output_dir}")
+        
+        channel_names = [ch.value for ch in self.channels]
+        
+        return visualize_dataset_sample(
+            self.output_dir,
+            channel_names,
+            num_samples=num_samples,
+            seed=self.seed,
+            figsize=figsize
+        )
+    
+    def visualize_image(
+        self,
+        image_id: int,
+        figsize: tuple = (15, 5)
+    ):
+        
+        if not self.output_dir.exists():
+            raise ValueError(f"Dataset directory does not exist: {self.output_dir}")
+        
+        channel_names = [ch.value for ch in self.channels]
+        
+        return visualize_single_image(
+            self.output_dir,
+            image_id,
+            channel_names,
+            figsize=figsize
+        )
+    
+    def verify_dataset(self) -> Dict:
+        
+        if not self.output_dir.exists():
+            raise ValueError(f"Dataset directory does not exist: {self.output_dir}")
+        
+        channel_names = [ch.value for ch in self.channels]
+        
+        results = verify_dataset_structure(self.output_dir, channel_names)
+        
+        print("\n=== Dataset Verification ===")
+        print(f"Valid: {results['valid']}")
+        
+        if results['issues']:
+            print("\nIssues found:")
+            for issue in results['issues']:
+                print(f"  - {issue}")
+        
+        print("\nStatistics:")
+        for key, value in results['statistics'].items():
+            print(f"  {key}: {value}")
+        
+        return results
+
+
+def list_available_batches(dataset_type: str = "pilot", source: str = "source_4") -> List[str]:
+    
+    if dataset_type.lower() == "pilot":
+        metadata = load_pilot_metadata(source)
+        batches = metadata.select("Metadata_Batch").unique().collect()
+        return sorted(batches["Metadata_Batch"].to_list())
+    else:
+        raise NotImplementedError(f"Batch listing not implemented for {dataset_type}")
+
+
+def get_batch_info(batch: str, source: str = "source_4") -> Dict:
+    
+    metadata = load_pilot_metadata(source)
+    plates = get_plates_in_batch(metadata, batch)
+    
+    return {
+        "batch": batch,
+        "num_plates": len(plates),
+        "plates": plates
+    }

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_image_fetch.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_image_fetch.py
@@ -1,0 +1,66 @@
+from typing import Optional
+import numpy as np
+from jump_portrait.fetch import get_jump_image as jp_get_jump_image
+
+
+def fetch_jump_image(
+    source: str,
+    batch: str,
+    plate: str,
+    well: str,
+    channel: str,
+    site: int,
+    correction: Optional[str] = None
+) -> np.ndarray:
+    
+    try:
+        image = jp_get_jump_image(
+            source=source,
+            batch=batch,
+            plate=plate,
+            well=well,
+            channel=channel,
+            site=site,
+            correction=correction
+        )
+        return image
+    
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to fetch image: {source}/{batch}/{plate}/{well}/{channel}/site_{site}"
+        ) from e
+
+
+def fetch_all_channels(
+    source: str,
+    batch: str,
+    plate: str,
+    well: str,
+    site: int,
+    channels: list[str],
+    correction: Optional[str] = None
+) -> dict[str, np.ndarray]:
+    
+    channel_images = {}
+    failed_channels = []
+    
+    for channel in channels:
+        try:
+            image = fetch_jump_image(
+                source=source,
+                batch=batch,
+                plate=plate,
+                well=well,
+                channel=channel,
+                site=site,
+                correction=correction
+            )
+            channel_images[channel] = image
+        except RuntimeError as e:
+            failed_channels.append((channel, str(e)))
+    
+    if failed_channels:
+        failed_str = ", ".join([f"{ch}: {err}" for ch, err in failed_channels])
+        raise RuntimeError(f"Failed to fetch channels: {failed_str}")
+    
+    return channel_images

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_metadata.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_metadata.py
@@ -1,0 +1,116 @@
+from typing import List, Optional, Dict
+import polars as pl
+import requests
+from jump_portrait.fetch import get_jump_image, get_item_location_info
+
+
+MANIFEST_URL = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.11.0/manifests/profile_index.json"
+
+
+def _load_manifest() -> List[Dict]:
+    response = requests.get(MANIFEST_URL)
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_dataset_url(subset: str) -> str:
+    manifest = _load_manifest()
+    for dataset in manifest:
+        if dataset['subset'] == subset:
+            return dataset['url']
+    raise ValueError(f"Dataset subset '{subset}' not found in manifest")
+
+
+def load_pilot_metadata(source: str = "source_4") -> pl.LazyFrame:
+    return pl.scan_parquet(
+        f"https://cellpainting-gallery.s3.amazonaws.com/cpg0000-jump-pilot/{source}/workspace/metadata/*/*.parquet"
+    )
+
+
+def load_orf_profiles(source: str = "source_4") -> pl.LazyFrame:
+    orf_url = _get_dataset_url('orf')
+    return pl.scan_parquet(orf_url)
+
+
+def load_compound_profiles(source: str = "source_4") -> pl.LazyFrame:
+    compound_url = _get_dataset_url('compound')
+    return pl.scan_parquet(compound_url)
+
+
+def load_crispr_profiles(source: str = "source_4") -> pl.LazyFrame:
+    crispr_url = _get_dataset_url('crispr')
+    return pl.scan_parquet(crispr_url)
+
+
+def get_location_info(perturbation_id: str, gene_symbol: Optional[str] = None) -> pl.DataFrame:
+    """
+    Get location info for a perturbation.
+    
+    For ORF data, gene_symbol must be provided because get_item_location_info()
+    expects gene symbols, not JCP2022 IDs.
+    """
+    try:
+        query_id = gene_symbol if gene_symbol else perturbation_id
+        location_df = get_item_location_info(query_id)
+        return location_df
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to get location info for {perturbation_id} "
+            f"(gene_symbol: {gene_symbol})"
+        ) from e
+
+
+def filter_by_batch(metadata: pl.LazyFrame, batch: str) -> pl.DataFrame:
+    return metadata.filter(pl.col("Metadata_Batch") == batch).collect()
+
+
+def get_plates_in_batch(metadata: pl.LazyFrame, batch: str) -> List[str]:
+    filtered = filter_by_batch(metadata, batch)
+    plates = filtered.select("Metadata_Plate").unique().to_series().to_list()
+    return sorted(plates)
+
+
+def get_wells_in_plate(
+    metadata: pl.LazyFrame,
+    batch: str,
+    plate: str
+) -> List[str]:
+    
+    filtered = metadata.filter(
+        (pl.col("Metadata_Batch") == batch) &
+        (pl.col("Metadata_Plate") == plate)
+    ).collect()
+    
+    wells = filtered.select("Metadata_Well").unique().to_series().to_list()
+    return sorted(wells)
+
+
+def sample_locations_from_plate(
+    metadata: pl.LazyFrame,
+    batch: str,
+    plate: str,
+    num_samples: int,
+    seed: int = 42
+) -> pl.DataFrame:
+    
+    filtered = metadata.filter(
+        (pl.col("Metadata_Batch") == batch) &
+        (pl.col("Metadata_Plate") == plate)
+    ).collect()
+    
+    if len(filtered) < num_samples:
+        raise ValueError(
+            f"Requested {num_samples} samples but only {len(filtered)} available"
+        )
+    
+    return filtered.sample(n=num_samples, seed=seed)
+
+
+def extract_location_from_row(row: dict) -> tuple[str, str, str, str, int]:
+    source = row["Metadata_Source"]
+    batch = row["Metadata_Batch"]
+    plate = row["Metadata_Plate"]
+    well = row["Metadata_Well"]
+    site = row["Metadata_Site"]
+    
+    return source, batch, plate, well, site

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_orf_dataset.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_orf_dataset.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+from typing import List, Optional, Dict
+import numpy as np
+from .jump_dataset_creation import (
+    ImageMetadata,
+    Channel,
+    validate_channels,
+    validate_weights,
+    create_directory_structure,
+    combine_channels,
+    save_images,
+    save_metadata,
+    print_dataset_summary
+)
+from .jump_metadata import (
+    load_orf_profiles,
+    get_location_info,
+    extract_location_from_row
+)
+from .jump_image_fetch import fetch_all_channels
+from .jump_perturbation_selection import get_orf_gene_mapping
+
+
+def create_orf_dataset(
+    orf_ids: List[str],
+    channels: List[Channel],
+    output_dir: Path,
+    images_per_orf: int = 5,
+    normalize: bool = False,
+    weights: Optional[List[float]] = None,
+    seed: int = 42,
+    source: str = "source_4",
+    gene_mapping: Optional[Dict[str, str]] = None
+) -> List[ImageMetadata]:
+    
+    validate_channels(channels)
+    channel_names = [ch.value for ch in channels]
+    weights = validate_weights(weights, len(channels))
+    
+    create_directory_structure(output_dir, channels)
+    
+    if gene_mapping is None:
+        profiles = load_orf_profiles(source)
+        gene_mapping = get_orf_gene_mapping(profiles)
+    
+    metadata_list = []
+    image_counter = 0
+    
+    total_target = len(orf_ids) * images_per_orf
+    print(f"Creating ORF dataset: {len(orf_ids)} ORFs × {images_per_orf} images = {total_target} total images")
+    print(f"Output directory: {output_dir}")
+    
+    np.random.seed(seed)
+    
+    for orf_idx, orf_id in enumerate(orf_ids, 1):
+        gene_symbol = gene_mapping.get(orf_id, None)
+        
+        if not gene_symbol:
+            print(f"\nSkipping ORF {orf_idx}/{len(orf_ids)}: {orf_id} (no gene symbol found)")
+            continue
+            
+        print(f"\nProcessing ORF {orf_idx}/{len(orf_ids)}: {orf_id}")
+        print(f"Gene symbol: {gene_symbol}")
+        
+        try:
+            location_info = get_location_info(orf_id, gene_symbol=gene_symbol)
+        except RuntimeError as e:
+            print(f"Skipping {orf_id}: {e}")
+            continue
+        
+        if len(location_info) == 0:
+            print(f"No images found for {gene_symbol}")
+            continue
+        
+        available_images = len(location_info)
+        num_to_sample = min(images_per_orf, available_images)
+        
+        if num_to_sample < images_per_orf:
+            print(f"Warning: Only {available_images} images available, sampling {num_to_sample}")
+        
+        sampled_indices = np.random.choice(
+            available_images,
+            size=num_to_sample,
+            replace=False
+        )
+        
+        images_processed = 0
+        
+        for sample_idx in sampled_indices:
+            row = location_info.row(int(sample_idx), named=True)
+            source_str, batch, plate, well, site = extract_location_from_row(row)
+            
+            print(f"Processing image {images_processed + 1}/{num_to_sample}: {source_str}/{batch}/{plate}/{well}/site_{site}")
+            
+            try:
+                channel_images = fetch_all_channels(
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                
+                combined_image, stats = combine_channels(
+                    channel_images,
+                    channel_names,
+                    weights,
+                    normalize
+                )
+                
+                save_images(
+                    combined_image,
+                    channel_images,
+                    image_counter,
+                    output_dir,
+                    channel_names
+                )
+                
+                metadata = ImageMetadata(
+                    image_id=image_counter,
+                    perturbation_id=orf_id,
+                    perturbation_type="orf",
+                    source=source_str,
+                    batch=batch,
+                    plate=plate,
+                    well=well,
+                    site=site,
+                    channels=channel_names,
+                    gene_symbol=gene_symbol
+                )
+                metadata_list.append(metadata)
+                
+                image_counter += 1
+                images_processed += 1
+                
+            except RuntimeError as e:
+                print(f"Failed to process image: {e}")
+                continue
+        
+        print(f"Successfully processed {images_processed}/{num_to_sample} images for {orf_id}")
+    
+    save_metadata(metadata_list, output_dir)
+    print_dataset_summary(metadata_list, output_dir, channel_names)
+    
+    return metadata_list

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_perturbation_selection.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_perturbation_selection.py
@@ -1,0 +1,149 @@
+from typing import List, Optional, Dict
+import polars as pl
+import pandas as pd
+import numpy as np
+import requests
+import gzip
+from io import StringIO
+
+
+def load_orf_gene_mapping() -> Dict[str, str]:
+    """
+    Load ORF metadata from GitHub to get JCP2022 -> Gene Symbol mapping.
+    This is required because get_item_location_info() expects gene symbols, not JCP IDs.
+    """
+    url = "https://raw.githubusercontent.com/jump-cellpainting/datasets/main/metadata/orf.csv.gz"
+    response = requests.get(url)
+    response.raise_for_status()
+    
+    content = gzip.decompress(response.content).decode('utf-8')
+    orf_metadata_df = pd.read_csv(StringIO(content))
+    
+    mapping = dict(zip(
+        orf_metadata_df['Metadata_JCP2022'],
+        orf_metadata_df['Metadata_Symbol']
+    ))
+    
+    return mapping
+
+
+def get_orf_gene_mapping(profiles: pl.LazyFrame) -> Dict[str, str]:
+    """
+    Get ORF gene mapping from GitHub metadata.
+    Returns dict mapping JCP2022 IDs to gene symbols.
+    """
+    return load_orf_gene_mapping()
+
+
+def select_orfs_by_gene(
+    profiles: pl.LazyFrame,
+    gene_symbols: List[str]
+) -> List[str]:
+    
+    orf_data = profiles.filter(
+        pl.col("Metadata_Symbol").is_in(gene_symbols)
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    return orf_data["Metadata_JCP2022"].to_list()
+
+
+def select_random_orfs(
+    profiles: pl.LazyFrame,
+    num_orfs: int,
+    seed: int = 42
+) -> List[str]:
+    
+    orf_data = profiles.filter(
+        pl.col("Metadata_JCP2022").str.starts_with("JCP2022_")
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    np.random.seed(seed)
+    all_orfs = orf_data["Metadata_JCP2022"].to_list()
+    
+    if len(all_orfs) < num_orfs:
+        raise ValueError(
+            f"Requested {num_orfs} ORFs but only {len(all_orfs)} available"
+        )
+    
+    selected = np.random.choice(all_orfs, size=num_orfs, replace=False)
+    return selected.tolist()
+
+
+def select_crispr_by_gene(
+    profiles: pl.LazyFrame,
+    gene_symbols: List[str]
+) -> List[str]:
+    
+    crispr_data = profiles.filter(
+        pl.col("Metadata_Symbol").is_in(gene_symbols) &
+        pl.col("Metadata_pert_type").str.contains("CRISPR")
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    return crispr_data["Metadata_JCP2022"].to_list()
+
+
+def select_random_crispr(
+    profiles: pl.LazyFrame,
+    num_perturbations: int,
+    seed: int = 42
+) -> List[str]:
+    
+    crispr_data = profiles.filter(
+        pl.col("Metadata_pert_type").str.contains("CRISPR")
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    np.random.seed(seed)
+    all_crispr = crispr_data["Metadata_JCP2022"].to_list()
+    
+    if len(all_crispr) < num_perturbations:
+        raise ValueError(
+            f"Requested {num_perturbations} CRISPR but only {len(all_crispr)} available"
+        )
+    
+    selected = np.random.choice(all_crispr, size=num_perturbations, replace=False)
+    return selected.tolist()
+
+
+def select_compounds_by_id(
+    profiles: pl.LazyFrame,
+    compound_ids: List[str]
+) -> List[str]:
+    
+    compound_data = profiles.filter(
+        pl.col("Metadata_JCP2022").is_in(compound_ids) &
+        pl.col("Metadata_pert_type").str.contains("compound")
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    return compound_data["Metadata_JCP2022"].to_list()
+
+
+def select_random_compounds(
+    profiles: pl.LazyFrame,
+    num_compounds: int,
+    seed: int = 42
+) -> List[str]:
+    
+    compound_data = profiles.filter(
+        pl.col("Metadata_pert_type").str.contains("compound")
+    ).select("Metadata_JCP2022").unique().collect()
+    
+    np.random.seed(seed)
+    all_compounds = compound_data["Metadata_JCP2022"].to_list()
+    
+    if len(all_compounds) < num_compounds:
+        raise ValueError(
+            f"Requested {num_compounds} compounds but only {len(all_compounds)} available"
+        )
+    
+    selected = np.random.choice(all_compounds, size=num_compounds, replace=False)
+    return selected.tolist()
+
+
+def get_perturbation_type(perturbation_id: str) -> str:
+    
+    if "JCP2022_" in perturbation_id:
+        return "orf"
+    elif "CRISPR" in perturbation_id.upper():
+        return "crispr"
+    else:
+        return "compound"

--- a/src/microsplit_reproducibility/workflows/dataset_creation/jump_pilot_dataset.py
+++ b/src/microsplit_reproducibility/workflows/dataset_creation/jump_pilot_dataset.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from typing import List, Optional
+import numpy as np
+from .jump_dataset_creation import (
+    DatasetConfig,
+    ImageMetadata,
+    Channel,
+    JUMPDataset,
+    validate_channels,
+    validate_weights,
+    create_directory_structure,
+    combine_channels,
+    save_images,
+    save_metadata,
+    print_dataset_summary
+)
+from .jump_metadata import (
+    load_pilot_metadata,
+    filter_by_batch,
+    get_plates_in_batch,
+    sample_locations_from_plate,
+    extract_location_from_row
+)
+from .jump_image_fetch import fetch_all_channels
+
+
+def create_pilot_dataset(
+    batch: str,
+    channels: List[Channel],
+    output_dir: Path,
+    samples_per_plate: int = 5,
+    plates: Optional[List[str]] = None,
+    normalize: bool = False,
+    weights: Optional[List[float]] = None,
+    seed: int = 42,
+    source: str = "source_4"
+) -> List[ImageMetadata]:
+    
+    validate_channels(channels)
+    channel_names = [ch.value for ch in channels]
+    weights = validate_weights(weights, len(channels))
+    
+    create_directory_structure(output_dir, channels)
+    
+    metadata_list = []
+    image_counter = 0
+    
+    pilot_metadata = load_pilot_metadata(source)
+    
+    if plates is None:
+        plates = get_plates_in_batch(pilot_metadata, batch)
+    
+    print(f"Creating dataset from batch: {batch}")
+    print(f"Found {len(plates)} plates")
+    print(f"Target: {samples_per_plate} samples per plate ({len(plates) * samples_per_plate} total)")
+    print(f"Output directory: {output_dir}")
+    
+    for plate_idx, plate in enumerate(plates, 1):
+        print(f"\nProcessing plate {plate_idx}/{len(plates)}: {plate}")
+        print(f"Target samples for this plate: {samples_per_plate}")
+        
+        try:
+            samples = sample_locations_from_plate(
+                pilot_metadata,
+                batch,
+                plate,
+                samples_per_plate,
+                seed=seed + plate_idx
+            )
+        except ValueError as e:
+            print(f"Skipping plate {plate}: {e}")
+            continue
+        
+        samples_processed = 0
+        
+        for sample_idx, row in enumerate(samples.iter_rows(named=True), 1):
+            source, batch_name, plate_name, well, site = extract_location_from_row(row)
+            
+            print(f"Processing sample {sample_idx}/{samples_per_plate}: Well {well}, Site {site}")
+            
+            try:
+                channel_images = fetch_all_channels(
+                    source=source,
+                    batch=batch_name,
+                    plate=plate_name,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                
+                combined_image, stats = combine_channels(
+                    channel_images,
+                    channel_names,
+                    weights,
+                    normalize
+                )
+                
+                save_images(
+                    combined_image,
+                    channel_images,
+                    image_counter,
+                    output_dir,
+                    channel_names
+                )
+                
+                metadata = ImageMetadata(
+                    image_id=image_counter,
+                    perturbation_id=f"{batch}_{plate}_{well}_{site}",
+                    perturbation_type="pilot",
+                    source=source,
+                    batch=batch_name,
+                    plate=plate_name,
+                    well=well,
+                    site=site,
+                    channels=channel_names
+                )
+                metadata_list.append(metadata)
+                
+                image_counter += 1
+                samples_processed += 1
+                
+            except RuntimeError as e:
+                print(f"Failed to process sample: {e}")
+                continue
+        
+        print(f"Successfully processed {samples_processed}/{samples_per_plate} samples from this plate")
+    
+    save_metadata(metadata_list, output_dir)
+    print_dataset_summary(metadata_list, output_dir, channel_names)
+    
+    return metadata_list


### PR DESCRIPTION
- Create unified DatasetBuilder for pilot/ORF/CRISPR/compound datasets
- Support flexible channel selection
- Add perturbation selection (random, by gene, specific IDs)
- Visualization and verification utilities
- Load data from AWS Cell Painting Gallery
- Use manifest-based loading for version-agnostic dataset access
- Implement gene symbol mapping 
- Add seed control for reproducibility

Modules:
- Core: dataset_creation, image_fetch, metadata, perturbation_selection, visualization
- Dataset-specific: pilot_dataset, orf_dataset, crispr_dataset, compound_dataset

resolves #1 